### PR TITLE
Bump untilBuild supported IJ version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("212")
-        untilBuild.set("222.*")
+        untilBuild.set("223.*")
     }
 
     signPlugin {


### PR DESCRIPTION
I typically always use the IntelliJ EAP builds, and it has recently bumped to a higher version than this plugin specifies.

note: I have not tested this, as I could not find instructions for building locally so I could test it in my existing IDE