### PR TITLE
Fix build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ IntelliJ plugin for Earthly language support.
 ## Building
 The following command generates a `earthly-intellij-plugin-<version>.zip` package in the current directory:
 ```
-earthly +build [--version=<version>]
+earthly +dist [--version=<version>]
 ```
 
 ## Signing (requires `earthly-technologies` org membership)


### PR DESCRIPTION
I thought about renaming `+dist` to `+build` or creating a duplicate target (as gradle users are accustomed to `gradle build`, so `earthly +build` would look natural), but opted for the simple fix.