### PR TITLE
Lock gradle version

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -44,3 +44,10 @@ ide:
   LOCALLY
   DO +GET_BUNDLE
   RUN gradle runIde
+
+generate-gradle-wrapper:
+  # Simply running 'wrapper' results in downloading the actual project dependencies,
+  # which is a waste, so we create a dummy project and generate a wrapper from that.
+  WORKDIR /tmp/wrap
+  RUN gradle --no-daemon init wrapper
+  SAVE ARTIFACT ./gradle AS LOCAL ./gradle

--- a/Earthfile
+++ b/Earthfile
@@ -1,5 +1,6 @@
 VERSION 0.6
-FROM gradle:jdk17
+ARG gradle_version=8.2.1
+FROM gradle:${gradle_version}-jdk17
 RUN apt-get update && apt-get install -y \
   zip \
   && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ The following command generates a `earthly-intellij-plugin-<version>.zip` packag
 earthly +build [--version=<version>]
 ```
 
+For local development, this will generate a gradle wrapper (`gradle/`) corresponding to the gradle version used in the build itself:
+```
+earthly +generate-gradle-wrapper
+```
+
 ## Signing (requires `earthly-technologies` org membership)
 The following command generates a `earthly-intellij-plugin-signed-<version>.zip` package in the current directory:
 ```


### PR DESCRIPTION
While #13 was truly a one-line fix that produced a good plugin, the build scripts were throwing all sorts of nasty errors in the IDE itself.  It took a while to discover it was a gradle version issue, and then saw the wrapper wasn't actually in the repo itself.

Assuming that was an intentional decision, I figured this was the next best thing.  Though there's still a chance one can get "out of sync" (due to the manual step of needing to run the target), it's now just one command.  The explicit `ARG` is a visual indicator as well.  Even if you don't like the new target, the `ARG` at least allows one to easily see what version to download, rather than having to a `docker run` or `docker inspect` to find the version.