### PR TITLE
Set gradle caches

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,6 +1,6 @@
 VERSION --pass-args --global-cache 0.7
 PROJECT earthly-technologies/core
-IMPORT github.com/earthly/lib/gradle:83b97695005665da1e97d0e4b8ac2213868f649316d9e15576a4e600126ab2ee AS gradle
+IMPORT github.com/earthly/lib/gradle:40a4041e3044e99cf192d05d4d1620a380d5ddc8 AS gradle
 ARG --global gradle_version=8.2.1
 ARG --global bundle="github.com/earthly/earthfile-grammar+export/"
 
@@ -14,22 +14,23 @@ install:
   DO gradle+GRADLE_GET_MOUNT_CACHE
 
 src:
+  ARG --required version
   FROM +install
   COPY src src
   COPY scripts scripts
   COPY $bundle build/
   RUN scripts/bundle.sh build/earthfile-syntax-highlighting
+  RUN sed -i 's^0.0.0^'"$version"'^g' ./build.gradle.kts
 
 dist:
-  FROM +src
   ARG version=0.0.0
-  RUN sed -i 's^0.0.0^'"$version"'^g' ./build.gradle.kts
+  FROM +src --version=$version
   RUN --mount=$EARTHLY_GRADLE_USER_HOME_CACHE --mount=$EARTHLY_GRADLE_PROJECT_CACHE gradle --no-daemon buildPlugin
   SAVE ARTIFACT build/distributions/earthly-intellij-plugin-$version.zip AS LOCAL earthly-intellij-plugin-$version.zip
 
 sign:
   ARG --required version
-  FROM +src
+  FROM --pass-args +src
   RUN --mount=$EARTHLY_GRADLE_USER_HOME_CACHE --mount=$EARTHLY_GRADLE_PROJECT_CACHE \
     --secret CERTIFICATE_CHAIN=intellij-plugin/chain.crt \
     --secret PRIVATE_KEY=intellij-plugin/private.pem \
@@ -39,7 +40,7 @@ sign:
 
 publish:
   ARG --required version
-  FROM --pass-args +sign
+  FROM --pass-args +src
   RUN --push \
     $EARTHLY_GRADLE_MOUNT_CACHE \
     --secret CERTIFICATE_CHAIN=intellij-plugin/chain.crt \

--- a/Earthfile
+++ b/Earthfile
@@ -19,11 +19,11 @@ install:
   DO gradle+GRADLE_GET_MOUNT_CACHE
 
 src:
-  ARG --required version
   FROM +install
   COPY src src
   COPY scripts scripts
   DO +GET_BUNDLE
+  ARG --required version
   RUN sed -i 's^0.0.0^'"$version"'^g' ./build.gradle.kts
 
 # dist builds the plugin and saves the artifact locally

--- a/Earthfile
+++ b/Earthfile
@@ -1,43 +1,51 @@
-VERSION 0.7
-ARG gradle_version=8.2.1
-FROM gradle:${gradle_version}-jdk17
-RUN apt-get update && apt-get install -y \
-  zip \
-  && rm -rf /var/lib/apt/lists/*
-ARG --global version=0.0.0
+VERSION --pass-args --global-cache 0.7
+PROJECT earthly-technologies/core
+IMPORT github.com/earthly/lib/gradle:83b97695005665da1e97d0e4b8ac2213868f649316d9e15576a4e600126ab2ee AS gradle
+ARG --global gradle_version=8.2.1
 ARG --global bundle="github.com/earthly/earthfile-grammar+export/"
-COPY settings.gradle.kts build.gradle.kts ./
-COPY scripts scripts
-COPY src src
 
-GET_BUNDLE:
-  COMMAND
+install:
+  FROM gradle:${gradle_version}-jdk17
+  RUN apt-get update && apt-get install -y \
+    zip \
+    && rm -rf /var/lib/apt/lists/*
+  COPY settings.gradle.kts build.gradle.kts ./
+  # Sets $EARTHLY_GRADLE_USER_HOME_CACHE and $EARTHLY_GRADLE_PROJECT_CACHE
+  DO gradle+GRADLE_GET_MOUNT_CACHE
+
+src:
+  FROM +install
+  COPY src src
+  COPY scripts scripts
   COPY $bundle build/
   RUN scripts/bundle.sh build/earthfile-syntax-highlighting
 
 dist:
-  DO +GET_BUNDLE
+  FROM +src
+  ARG version=0.0.0
   RUN sed -i 's^0.0.0^'"$version"'^g' ./build.gradle.kts
-  RUN --mount=type=cache,target=/root/.gradle/caches gradle --no-daemon buildPlugin
+  RUN --mount=$EARTHLY_GRADLE_USER_HOME_CACHE --mount=$EARTHLY_GRADLE_PROJECT_CACHE gradle --no-daemon buildPlugin
   SAVE ARTIFACT build/distributions/earthly-intellij-plugin-$version.zip AS LOCAL earthly-intellij-plugin-$version.zip
 
 sign:
-  FROM +dist
-  RUN --mount=type=cache,target=/root/.gradle/caches \
-    --secret CERTIFICATE_CHAIN=+secrets/earthly-technologies/intellij-plugin/chain.crt \
-    --secret PRIVATE_KEY=+secrets/earthly-technologies/intellij-plugin/private.pem \
-    --secret PRIVATE_KEY_PASSWORD=+secrets/earthly-technologies/intellij-plugin/private-key-password \
+  ARG --required version
+  FROM +src
+  RUN --mount=$EARTHLY_GRADLE_USER_HOME_CACHE --mount=$EARTHLY_GRADLE_PROJECT_CACHE \
+    --secret CERTIFICATE_CHAIN=intellij-plugin/chain.crt \
+    --secret PRIVATE_KEY=intellij-plugin/private.pem \
+    --secret PRIVATE_KEY_PASSWORD=intellij-plugin/private-key-password \
     gradle --no-daemon signPlugin
   SAVE ARTIFACT build/distributions/earthly-intellij-plugin-$version.zip AS LOCAL earthly-intellij-plugin-signed-$version.zip
 
 publish:
-  FROM +sign
+  ARG --required version
+  FROM --pass-args +sign
   RUN --push \
-    --mount=type=cache,target=/root/.gradle/caches \
-    --secret CERTIFICATE_CHAIN=+secrets/earthly-technologies/intellij-plugin/chain.crt \
-    --secret PRIVATE_KEY=+secrets/earthly-technologies/intellij-plugin/private.pem \
-    --secret PRIVATE_KEY_PASSWORD=+secrets/earthly-technologies/intellij-plugin/private-key-password \
-    --secret PUBLISH_TOKEN=+secrets/earthly-technologies/intellij-plugin/marketplace-token \
+    $EARTHLY_GRADLE_MOUNT_CACHE \
+    --secret CERTIFICATE_CHAIN=intellij-plugin/chain.crt \
+    --secret PRIVATE_KEY=intellij-plugin/private.pem \
+    --secret PRIVATE_KEY_PASSWORD=intellij-plugin/private-key-password \
+    --secret PUBLISH_TOKEN=intellij-plugin/marketplace-token \
     gradle --no-daemon publishPlugin
 
 ide:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java")
-    id("org.jetbrains.intellij") version "1.16.0"
+    id("org.jetbrains.intellij") version "1.16.1"
 }
 
 dependencies {
@@ -34,7 +34,7 @@ tasks {
     }
 
     patchPluginXml {
-        sinceBuild.set("223")
+        sinceBuild.set("212")
         untilBuild.set("233.*")
     }
 

--- a/src/main/java/dev/earthly/plugin/language/syntax/highlighting/EarthlySyntaxHighlighterFactory.java
+++ b/src/main/java/dev/earthly/plugin/language/syntax/highlighting/EarthlySyntaxHighlighterFactory.java
@@ -4,8 +4,6 @@ import com.intellij.openapi.fileTypes.SyntaxHighlighter;
 import com.intellij.openapi.fileTypes.SyntaxHighlighterFactory;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
-import dev.earthly.plugin.language.syntax.highlighting.EarthlyHighlighter;
-import dev.earthly.plugin.language.syntax.highlighting.EarthlyHighlightingLexer;
 import org.jetbrains.annotations.NotNull;
 
 public class EarthlySyntaxHighlighterFactory extends SyntaxHighlighterFactory {


### PR DESCRIPTION
Gradle artifacts are not properly cached, and dependencies are re-downloaded. This PR fixes it by making use of https://github.com/earthly/lib/pull/37