### PR TITLE
Bump support to 251.*

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("232")
-        untilBuild.set("243.*")
+        untilBuild.set("251.*")
     }
 
     signPlugin {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -30,7 +30,7 @@
   <change-notes><![CDATA[
 <h2>New Features</h2>
 <ul>
- <li>Add support for platform build 243</li>
+ <li>Add support for platform build 251</li>
 </ul>
 ]]>
   </change-notes>


### PR DESCRIPTION
Make plugin compatible with newest Intellij release.

Note that "the tests pass" and appears to be working as before, but it does warn of a possible memory leak:
```
<snip>
               +dist | 2025-04-16 17:12:16,760 [  12478] SEVERE - #c.i.o.u.ObjectTree - Memory leak detected: 'newDisposable' (class com.intellij.openapi.util.Disposer$1) was registered in Disposer as a child of 'ROOT_DISPOSABLE' (class com.intellij.openapi.util.Disposer$2) but wasn't disposed.
               +dist | Register it with a proper parentDisposable or ensure that it's always disposed by direct Disposer.dispose call.
               +dist | See https://jetbrains.org/intellij/sdk/docs/basics/disposers.html for more details.
<snip>
```
As well, the plugin manifest shows multiple 'errors' regarding the optional plugin dependencies; that they can't be found and are missing a required attribute.  I don't recall seeing these during the last version bump.

It's likely the plugin needs to be modernized to perform optimally.  But since the tests pass, the plugin appears to be working fine, and the future of the earthly ecosystem is in question, I figured it'd be best to submit a quick fix rather than investing the time to see if those issues are important.